### PR TITLE
Add exam menu and route to navbar and routes

### DIFF
--- a/mln122_frontend/src/components/layout/Navbar/Navbar.tsx
+++ b/mln122_frontend/src/components/layout/Navbar/Navbar.tsx
@@ -5,11 +5,8 @@ import {
   LogoutOutlined,
   HomeFilled,
   QuestionCircleOutlined,
-
   MessageOutlined,
-
   BookOutlined,
-
 } from '@ant-design/icons'
 import hcmImage from '../../../assets/hcm.png'
 import type { MenuProps } from 'antd'
@@ -55,15 +52,14 @@ const StudentProjectNavbar: React.FC = () => {
       label: 'Trang chủ',
     },
     {
-
       key: 'chat',
       icon: <MessageOutlined />,
       label: 'Chat cùng AI',
-
+    },
+    {
       key: 'exam',
       icon: <BookOutlined />,
       label: 'Danh sách đề thi',
-
     },
     {
       key: 'survey',

--- a/mln122_frontend/src/routes/routes.ts
+++ b/mln122_frontend/src/routes/routes.ts
@@ -79,13 +79,12 @@ const routes: LayoutRoute[] = [
         component: Survey,
       },
       {
-
         path: '/chat',
         component: ChatAI,
-
+      },
+      {
         path: '/exam',
         component: HomePage,
-
       },
     ],
   },


### PR DESCRIPTION
Added a new 'Danh sách đề thi' (exam list) menu item to the navbar and mapped the '/exam' route to HomePage in the routes configuration. This provides navigation and routing for the exam list feature.